### PR TITLE
Fix : 1 pound = 453.59237gm

### DIFF
--- a/lib/default.units
+++ b/lib/default.units
@@ -15,7 +15,7 @@ distance:
 mass:
   ton,t			1000000gm
   gram,gm		1gm
-  pound,lb		16gm
+  pound,lb		453.59237gm
   ounce,oz		28.3495gm
   stone,st		6350.29gm
 


### PR DESCRIPTION
1 pound = 453.59237gm.

Initially, it was "1 pound = 16gm".
